### PR TITLE
Improve GPS Journey map and notifications

### DIFF
--- a/src/components/dashboard/DashboardHeader.tsx
+++ b/src/components/dashboard/DashboardHeader.tsx
@@ -1,6 +1,5 @@
-import { Bell, Search, User, Sun, Moon, Clock, CheckCircle2, X, DatabaseZap, CircleHelp, Calendar, LogOut, Sparkles } from "lucide-react";
+import { Bell, BellOff, User, X, DatabaseZap, CircleHelp, Calendar, LogOut, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -15,17 +14,43 @@ import { useNavigate } from "react-router-dom";
 import { GlobalSearch } from "./GlobalSearch";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getFileUrl } from "@/lib/directus";
-import {
-  getCaregiverServicesByDistrict
-} from "@/lib/api";
 import { markNotificationRead, clearAllNotifications } from "@/lib/directus";
+import { toast } from "sonner";
 import { formatDistanceToNow } from "date-fns";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import LoadingDots from "@/components/aceternity/LoadingDots";
-import { useRef, useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useRef } from "react";
 
-// Simple notification sound (Beep)
-const BEEP_SOUND = "data:audio/wav;base64,UklGRl9vT19XQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YU"; // Placeholder beep
+const SOUND_STORAGE_KEY = "ecapplus.notifications.sound";
+
+// Synthesized two-tone beep via the WebAudio API — no asset file needed,
+// works regardless of bundler/public-folder state.
+function playNotificationBeep() {
+  try {
+    const Ctx = (window as any).AudioContext || (window as any).webkitAudioContext;
+    if (!Ctx) return;
+    const ctx = new Ctx();
+    const gain = ctx.createGain();
+    gain.gain.value = 0.0001;
+    gain.connect(ctx.destination);
+
+    const tones = [880, 1320];
+    tones.forEach((freq, i) => {
+      const osc = ctx.createOscillator();
+      osc.type = "sine";
+      osc.frequency.value = freq;
+      osc.connect(gain);
+      const t = ctx.currentTime + i * 0.12;
+      osc.start(t);
+      gain.gain.setValueAtTime(0.0001, t);
+      gain.gain.exponentialRampToValueAtTime(0.18, t + 0.01);
+      gain.gain.exponentialRampToValueAtTime(0.0001, t + 0.09);
+      osc.stop(t + 0.1);
+    });
+    setTimeout(() => ctx.close().catch(() => {}), 400);
+  } catch {
+    // best-effort — silently swallow if WebAudio is unavailable
+  }
+}
 
 type DashboardHeaderProps = {
   title?: string;
@@ -46,13 +71,19 @@ const DashboardHeader = ({
       const { getNotifications } = await import("@/lib/directus");
       return getNotifications(user?.id); // Pass user.id for security
     },
-    staleTime: 1000 * 30, // 30 seconds
-    refetchInterval: 1000 * 30, // Poll every 30 seconds for performance & responsiveness
+    staleTime: 1000 * 25,
+    refetchInterval: 1000 * 30,
+    refetchIntervalInBackground: false,
+    refetchOnWindowFocus: true,
     enabled: !!user?.id,
   });
 
   const [prevUnreadCount, setPrevUnreadCount] = useState(0);
-  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const [soundEnabled, setSoundEnabled] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return window.localStorage.getItem(SOUND_STORAGE_KEY) !== "off";
+  });
+  const firstLoadRef = useRef(true);
 
   const notifications = useMemo(() => {
     return (directusNotifications ?? [])
@@ -78,16 +109,58 @@ const DashboardHeader = ({
 
   const unreadCount = notifications.length;
 
-  // Sound Logic
+  // Beep + system notification only when count grows AFTER the first load,
+  // and only if the tab is hidden / unfocused (so we don't beep at a user
+  // already looking at the dashboard).
   useEffect(() => {
+    if (firstLoadRef.current) {
+      firstLoadRef.current = false;
+      setPrevUnreadCount(unreadCount);
+      return;
+    }
     if (unreadCount > prevUnreadCount) {
-      // Play sound
-      if (audioRef.current) {
-        audioRef.current.play().catch(e => console.warn("Audio play failed:", e));
+      const delta = unreadCount - prevUnreadCount;
+      if (soundEnabled) playNotificationBeep();
+      if (
+        typeof window !== "undefined" &&
+        "Notification" in window &&
+        Notification.permission === "granted" &&
+        document.visibilityState !== "visible"
+      ) {
+        try {
+          new Notification("ECAP+ PMP", {
+            body: delta === 1 ? "You have a new notification" : `You have ${delta} new notifications`,
+            icon: "/ecap-logo.png",
+            silent: !soundEnabled,
+          });
+        } catch {
+          // best effort
+        }
       }
     }
     setPrevUnreadCount(unreadCount);
-  }, [unreadCount, prevUnreadCount]);
+  }, [unreadCount, prevUnreadCount, soundEnabled]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !("Notification" in window)) return;
+    if (Notification.permission === "default") {
+      Notification.requestPermission().catch(() => {});
+    }
+  }, []);
+
+  const toggleSound = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setSoundEnabled((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(SOUND_STORAGE_KEY, next ? "on" : "off");
+      } catch {
+        // ignore quota / privacy-mode failures
+      }
+      return next;
+    });
+  };
 
   const handleDismiss = async (id: string, e: React.MouseEvent) => {
     e.preventDefault();
@@ -97,6 +170,7 @@ const DashboardHeader = ({
       queryClient.invalidateQueries({ queryKey: ["directus-notifications"] });
     } catch (error) {
       console.error("Failed to dismiss notification:", error);
+      toast.error("Couldn't dismiss notification");
     }
   };
 
@@ -105,10 +179,12 @@ const DashboardHeader = ({
     e.stopPropagation();
     if (!user?.id) return;
     try {
-      await clearAllNotifications(user.id);
+      const cleared = await clearAllNotifications(user.id);
       queryClient.invalidateQueries({ queryKey: ["directus-notifications"] });
+      toast.success(cleared > 0 ? `Cleared ${cleared} notification${cleared === 1 ? "" : "s"}` : "Inbox already clear");
     } catch (error) {
       console.error("Failed to clear notifications:", error);
+      toast.error("Couldn't clear notifications");
     }
   };
 
@@ -201,14 +277,24 @@ const DashboardHeader = ({
                   </div>
                   <p className="mt-1 text-[11px] text-slate-500">Tasks and alerts for {district || "your area"}</p>
                 </div>
-                {unreadCount > 0 && (
+                <div className="flex items-center gap-1 shrink-0">
                   <button
-                    className="shrink-0 text-[10px] font-bold uppercase tracking-wider text-emerald-700 hover:text-emerald-800 transition-colors px-2 py-1 rounded-md hover:bg-emerald-50/70"
-                    onClick={handleClearAll}
+                    type="button"
+                    className="text-slate-400 hover:text-emerald-700 transition-colors p-1 rounded-md hover:bg-emerald-50/70"
+                    onClick={toggleSound}
+                    title={soundEnabled ? "Mute notification sound" : "Enable notification sound"}
                   >
-                    Clear all
+                    {soundEnabled ? <Bell className="h-3.5 w-3.5" /> : <BellOff className="h-3.5 w-3.5" />}
                   </button>
-                )}
+                  {unreadCount > 0 && (
+                    <button
+                      className="text-[10px] font-bold uppercase tracking-wider text-emerald-700 hover:text-emerald-800 transition-colors px-2 py-1 rounded-md hover:bg-emerald-50/70"
+                      onClick={handleClearAll}
+                    >
+                      Clear all
+                    </button>
+                  )}
+                </div>
               </div>
               <ScrollArea className="h-72">
                 {notifications.length === 0 ? (
@@ -346,7 +432,6 @@ const DashboardHeader = ({
           </DropdownMenu>
         </div>
       </div>
-      <audio ref={audioRef} src="/notification.wav" preload="auto" />
     </div>
   );
 };

--- a/src/lib/directus.ts
+++ b/src/lib/directus.ts
@@ -288,7 +288,7 @@ export const getNotifications = async (userId?: string) => {
     "filter[status][_eq]": "inbox",
     "filter[recipient][_eq]": userId, // SECURITY: Strictly filter by recipient
     "sort": "-timestamp",
-    "limit": "20",
+    "limit": "100",
     "fields": "id,subject,message,timestamp,collection,sender,recipient,item",
   });
 
@@ -338,14 +338,30 @@ export const sendMail = async (payload: {
 };
 
 
+/**
+ * Batch-archive every inbox notification for a user with a single Directus
+ * PATCH. Avoids the N+1 race where new notifications arriving mid-clear
+ * survived the loop, and removes the prior 20-item pagination cap.
+ */
 export const clearAllNotifications = async (userId: string) => {
   if (!userId) return 0;
-  const notifications = await getNotifications(userId);
-  await Promise.allSettled(
-    notifications.map((n: Notification) => markNotificationRead(n.id))
-  );
-  return notifications.length;
+  const params = new URLSearchParams({
+    "filter[recipient][_eq]": userId,
+    "filter[status][_eq]": "inbox",
+  });
+  const data = await directusRequest(`/notifications?${params.toString()}`, {
+    method: "PATCH",
+    body: JSON.stringify({ status: "archived" }),
+  });
+  return Array.isArray(data?.data) ? data.data.length : 0;
 };
+
+/**
+ * Batch-mark every inbox notification for a user as read (status: archived
+ * in this app's semantics is used for dismissal; "read" maps to archived
+ * for the dashboard bell badge).
+ */
+export const markAllNotificationsReadForUser = clearAllNotifications;
 
 /**
  * Manually triggers the Weekly Extract Notifications flow on the server.
@@ -408,14 +424,30 @@ export const notifyAllUsers = async (subject: string, message: string) => {
   return { sent, emailsSent, total: users.length };
 };
 
+// Roles that should be notified when a record is flagged / a flag is
+// resolved. Anything else (caseworkers, viewers) gets filtered out so we
+// stop blasting a notification to every active user in the system.
+const FLAG_NOTIFY_ROLE_KEYWORDS = ["admin", "administrator", "supervisor", "qa", "data quality", "manager"];
+
+const isFlagNotifyRecipient = (u: DirectusUser) => {
+  const roleName =
+    typeof u.role === "object" && u.role !== null
+      ? String((u.role as { name?: string }).name ?? "")
+      : "";
+  if (!roleName) return false;
+  const lower = roleName.toLowerCase();
+  return FLAG_NOTIFY_ROLE_KEYWORDS.some((k) => lower.includes(k));
+};
+
 export const notifyUsersOfFlag = async (hhId: string, verifier: string, comment: string, vcaId?: string) => {
-  const users = await listUsers("active");
+  const users = (await listUsers("active")) as DirectusUser[];
+  const recipients = users.filter(isFlagNotifyRecipient);
   const entityId = vcaId && vcaId !== "Not Available" ? `VCA ${vcaId} (HH ${hhId})` : `Household ${hhId}`;
   const subject = `Record Flagged: ${entityId}`;
   const message = `A record for ${entityId} has been flagged by ${verifier}. \n\nComment: ${comment}`;
 
   return Promise.allSettled(
-    users.map((u: DirectusUser) =>
+    recipients.map((u) =>
       createNotification({
         recipient: u.id,
         subject,
@@ -427,13 +459,14 @@ export const notifyUsersOfFlag = async (hhId: string, verifier: string, comment:
 };
 
 export const notifyUsersOfFlagResolution = async (hhId: string, resolver: string, comment: string, vcaId?: string) => {
-  const users = await listUsers("active");
+  const users = (await listUsers("active")) as DirectusUser[];
+  const recipients = users.filter(isFlagNotifyRecipient);
   const entityId = vcaId && vcaId !== "Not Available" ? `VCA ${vcaId} (HH ${hhId})` : `Household ${hhId}`;
   const subject = `Flag Resolved: ${entityId}`;
   const message = `The flag for ${entityId} has been resolved by ${resolver}. \n\nResolution/Comment: ${comment}`;
 
   return Promise.allSettled(
-    users.map((u: DirectusUser) =>
+    recipients.map((u) =>
       createNotification({
         recipient: u.id,
         subject,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,3 +15,40 @@ export function toSentenceCase(str: string) {
   const s = str.trim();
   return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 }
+
+/**
+ * Normalize a place name (ward / district / facility / province): trim, collapse
+ * internal whitespace, hyphen-aware Title Case. Names sourced from free-text DB
+ * fields routinely arrive lowercase ("chibale") or SHOUTING ("MULUNGUSHI"); this
+ * brings them to a consistent display form ("Chibale", "Mulungushi", "St-Anne's").
+ */
+export function normalizePlaceName(raw: unknown): string {
+  if (raw === null || raw === undefined) return "";
+  const s = String(raw).trim().replace(/\s+/g, " ");
+  if (!s) return "";
+  return s
+    .toLowerCase()
+    .split(" ")
+    .map((word) =>
+      word
+        .split("-")
+        .map((part) => (part ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+        .join("-"),
+    )
+    .join(" ");
+}
+
+/**
+ * Dedupe an array of place names case-insensitively, keeping the prettiest
+ * (Title-cased) representation. Stable: preserves input order.
+ */
+export function dedupePlaceNames(values: Array<string | null | undefined>): string[] {
+  const seen = new Map<string, string>();
+  for (const v of values) {
+    const pretty = normalizePlaceName(v);
+    if (!pretty) continue;
+    const key = pretty.toLowerCase();
+    if (!seen.has(key)) seen.set(key, pretty);
+  }
+  return Array.from(seen.values());
+}

--- a/src/pages/CaseworkerJourneys.tsx
+++ b/src/pages/CaseworkerJourneys.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { MapPin, Download, Filter, Navigation, CalendarIcon, Flame, Play, Pause, SkipBack, SkipForward, Check, ChevronsUpDown } from "lucide-react";
+import { MapPin, Download, Filter, Navigation, CalendarIcon, Flame, Play, Pause, SkipBack, SkipForward, Check, ChevronsUpDown, Maximize2, Minimize2 } from "lucide-react";
 import { MapContainer, TileLayer, CircleMarker, Popup, Polyline, useMap } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import L from "leaflet";
@@ -30,13 +30,52 @@ import {
 } from "@/components/ui/command";
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { cn, normalizePlaceName, dedupePlaceNames } from "@/lib/utils";
 import { useAuth } from "@/context/AuthContext";
 import { getCaseworkerJourneys, getCaseworkerList, getFacilityList } from "@/lib/api";
 import type { JourneyPoint } from "@/lib/api";
 
 const ZAMBIA_CENTER: [number, number] = [-13.1339, 27.8493];
 const DEFAULT_ZOOM = 6;
+
+// Map raw OpenSRP entityType values ("ec_household_service_report",
+// "ec_vca_case_plan", etc.) to human-friendly visit categories. The exposed
+// usernames-on-pin work is paired with this: we surface *what* happened at a
+// stop rather than the internal form name.
+function categorizeVisit(formType: unknown): string {
+  const t = String(formType ?? "").toLowerCase();
+  if (!t) return "Visit";
+  if (
+    t.includes("household") ||
+    t.includes("caregiver") ||
+    t.includes("mother") ||
+    t.includes("pmtct_mother") ||
+    t.includes("hh_")
+  ) return "Household Visit";
+  if (
+    t.includes("vca") ||
+    t.includes("child") ||
+    t.includes("client") ||
+    t.includes("hiv_assessment") ||
+    t.includes("hiv_testing") ||
+    t.includes("muac") ||
+    t.includes("grad") ||
+    t.includes("pmtct_child")
+  ) return "Child Visit";
+  return "Visit";
+}
+
+function visitLabel(types: Array<string | undefined | null>): string {
+  const cats = new Set<string>();
+  for (const t of types) {
+    const c = categorizeVisit(t);
+    if (c) cats.add(c);
+  }
+  if (cats.size === 0) return "Visit";
+  if (cats.size === 1) return [...cats][0];
+  if (cats.has("Household Visit") && cats.has("Child Visit")) return "Household & Child Visit";
+  return [...cats].join(", ");
+}
 
 // Heatmap layer component (uses leaflet.heat via useMap)
 function HeatmapLayer({ points }: { points: [number, number, number][] }) {
@@ -70,11 +109,11 @@ function PlaybackMarker({ position, point }: { position: [number, number]; point
       <Popup>
         <div className="text-sm space-y-0.5">
           <p className="font-semibold text-red-600">Current Position</p>
-          {point?.facility && <p className="text-blue-600 font-medium">{point.facility}</p>}
+          {point?.facility && <p className="text-blue-600 font-medium">{normalizePlaceName(point.facility)}</p>}
           <p className="text-slate-500">
             {point?.visit_date ? new Date(point.visit_date).toLocaleString("en-GB", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" }) : ""}
           </p>
-          <p className="text-slate-400 text-xs">{point?.form_type}</p>
+          <p className="text-slate-400 text-xs">{categorizeVisit(point?.form_type)}</p>
         </div>
       </Popup>
     </CircleMarker>
@@ -105,6 +144,22 @@ const CaseworkerJourneys = () => {
 
   // View mode: journey (default), heatmap, playback
   const [viewMode, setViewMode] = useState<"journey" | "heatmap" | "playback">("journey");
+
+  // Fullscreen toggle for the Journey Map card
+  const [isMapFullscreen, setIsMapFullscreen] = useState(false);
+  useEffect(() => {
+    if (!isMapFullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsMapFullscreen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isMapFullscreen]);
 
   // Playback state
   const [playbackIndex, setPlaybackIndex] = useState(0);
@@ -164,19 +219,24 @@ const CaseworkerJourneys = () => {
   //   Provincial User -> only facilities in their province (derived from caseworkerList)
   //   Admin / others  -> full list
   const facilities = useMemo(() => {
-    if (!isDistrictUser && !isProvincialUser) return allFacilities;
-    const allowed = new Set<string>();
-    (caseworkerList as any[]).forEach((cw) => {
-      const f = String(cw?.facility ?? "").trim();
-      if (f) allowed.add(f);
-    });
-    if (allowed.size === 0) return [];
-    const lc = new Set([...allowed].map((s) => s.toLowerCase()));
-    return allFacilities.filter((f: string) => lc.has(String(f).toLowerCase()));
+    const baseList = (() => {
+      if (!isDistrictUser && !isProvincialUser) return allFacilities;
+      const allowed = new Set<string>();
+      (caseworkerList as any[]).forEach((cw) => {
+        const f = String(cw?.facility ?? "").trim();
+        if (f) allowed.add(f);
+      });
+      if (allowed.size === 0) return [];
+      const lc = new Set([...allowed].map((s) => s.toLowerCase()));
+      return allFacilities.filter((f: string) => lc.has(String(f).toLowerCase()));
+    })();
+    // Title-case ward names ("chibale" → "Chibale") and collapse duplicates
+    // that differ only by case so the dropdown never lists "chibale" + "Chibale".
+    return dedupePlaceNames(baseList as string[]).sort((a, b) => a.localeCompare(b));
   }, [allFacilities, caseworkerList, isDistrictUser, isProvincialUser]);
 
   // Facility/ward filtering is client-side (applies live on selection, no Apply needed)
-  const validPoints = useMemo(() => {
+  const filteredPoints = useMemo(() => {
     if (selectedFacility && selectedFacility !== "all") {
       const filter = selectedFacility.toLowerCase();
       return allValidPoints.filter((p: any) => {
@@ -186,6 +246,34 @@ const CaseworkerJourneys = () => {
     }
     return allValidPoints;
   }, [allValidPoints, selectedFacility]);
+
+  // Collapse same (entity, date) into a single GPS marker so a caseworker who
+  // logged multiple services for the same household / VCA in one day shows
+  // as one dot, not a stack of overlapping markers. We attach the visit
+  // count and the unique form types so the popup can still surface that
+  // multiple things happened at that stop.
+  const validPoints = useMemo(() => {
+    const groups = new Map<string, { rep: any; visits: any[] }>();
+    for (const p of filteredPoints as any[]) {
+      const dateOnly = String(p.visit_date || "").slice(0, 10);
+      const idKey =
+        p.entity_id ||
+        p.household_id ||
+        `${Math.round(Number(p.lat) * 10000)},${Math.round(Number(p.lng) * 10000)}`;
+      const key = `${idKey}::${dateOnly}`;
+      const existing = groups.get(key);
+      if (existing) {
+        existing.visits.push(p);
+      } else {
+        groups.set(key, { rep: p, visits: [p] });
+      }
+    }
+    return Array.from(groups.values()).map(({ rep, visits }) => ({
+      ...rep,
+      visit_count: visits.length,
+      visit_form_types: Array.from(new Set(visits.map((v: any) => v.form_type).filter(Boolean))),
+    }));
+  }, [filteredPoints]);
 
   const sortedPoints = useMemo(
     () => [...validPoints].sort((a, b) => new Date(a.visit_date).getTime() - new Date(b.visit_date).getTime()),
@@ -198,7 +286,10 @@ const CaseworkerJourneys = () => {
   );
 
   const heatmapData = useMemo(
-    () => validPoints.map((p) => [Number(p.lat), Number(p.lng), 0.5] as [number, number, number]),
+    () => validPoints.map((p: any) => {
+      const weight = Math.min(0.3 + 0.15 * Number(p.visit_count || 1), 1);
+      return [Number(p.lat), Number(p.lng), weight] as [number, number, number];
+    }),
     [validPoints]
   );
 
@@ -412,7 +503,7 @@ const CaseworkerJourneys = () => {
                             (groups[facility] ||= []).push(cw);
                           });
                           return Object.entries(groups).map(([facility, members]) => (
-                            <CommandGroup key={facility} heading={facility}>
+                            <CommandGroup key={facility} heading={normalizePlaceName(facility)}>
                               {members.map((cw) => {
                                 const label = cw.display_name || cw.caseworker;
                                 const haystack = `${label} ${cw.facility || ""}`;
@@ -516,35 +607,49 @@ const CaseworkerJourneys = () => {
         </GlowCard>
 
         {/* Map Card */}
-        <GlowCard>
+        <div className={cn(isMapFullscreen && "fixed inset-0 z-[1000] bg-white overflow-auto")}>
+        <GlowCard
+          className={cn(isMapFullscreen && "rounded-none border-0 shadow-none")}
+        >
           <CardHeader className="pb-2">
             <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
               <CardTitle className="flex items-center gap-2 text-base">
                 <MapPin className="h-4 w-4" />
                 Journey Map
               </CardTitle>
-              {validPoints.length > 0 && (
-                <div className="flex items-center gap-1 p-1 bg-slate-100 rounded-xl">
-                  <button onClick={() => { setViewMode("journey"); setIsPlaying(false); }}
-                    className={cn("px-3 py-1.5 rounded-lg text-xs font-medium transition-all",
-                      viewMode === "journey" ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
-                    )}>
-                    <MapPin className="h-3 w-3 inline mr-1" /> Journey
-                  </button>
-                  <button onClick={() => { setViewMode("heatmap"); setIsPlaying(false); }}
-                    className={cn("px-3 py-1.5 rounded-lg text-xs font-medium transition-all",
-                      viewMode === "heatmap" ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
-                    )}>
-                    <Flame className="h-3 w-3 inline mr-1" /> Heatmap
-                  </button>
-                  <button onClick={() => { setViewMode("playback"); setPlaybackIndex(0); setIsPlaying(false); }}
-                    className={cn("px-3 py-1.5 rounded-lg text-xs font-medium transition-all",
-                      viewMode === "playback" ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
-                    )}>
-                    <Play className="h-3 w-3 inline mr-1" /> Playback
-                  </button>
-                </div>
-              )}
+              <div className="flex items-center gap-2 flex-wrap">
+                {validPoints.length > 0 && (
+                  <div className="flex items-center gap-1 p-1 bg-slate-100 rounded-xl">
+                    <button onClick={() => { setViewMode("journey"); setIsPlaying(false); }}
+                      className={cn("px-3 py-1.5 rounded-lg text-xs font-medium transition-all",
+                        viewMode === "journey" ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
+                      )}>
+                      <MapPin className="h-3 w-3 inline mr-1" /> Journey
+                    </button>
+                    <button onClick={() => { setViewMode("heatmap"); setIsPlaying(false); }}
+                      className={cn("px-3 py-1.5 rounded-lg text-xs font-medium transition-all",
+                        viewMode === "heatmap" ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
+                      )}>
+                      <Flame className="h-3 w-3 inline mr-1" /> Heatmap
+                    </button>
+                    <button onClick={() => { setViewMode("playback"); setPlaybackIndex(0); setIsPlaying(false); }}
+                      className={cn("px-3 py-1.5 rounded-lg text-xs font-medium transition-all",
+                        viewMode === "playback" ? "bg-white text-slate-900 shadow-sm" : "text-slate-500 hover:text-slate-700"
+                      )}>
+                      <Play className="h-3 w-3 inline mr-1" /> Playback
+                    </button>
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={() => setIsMapFullscreen((v) => !v)}
+                  className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50 hover:text-slate-900 transition-all"
+                  title={isMapFullscreen ? "Exit fullscreen (Esc)" : "Expand to fullscreen"}
+                >
+                  {isMapFullscreen ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+                  <span className="hidden sm:inline">{isMapFullscreen ? "Exit" : "Fullscreen"}</span>
+                </button>
+              </div>
             </div>
             {validPoints.length > 0 && (
               <div className="flex flex-wrap items-center gap-4 mt-2 text-xs">
@@ -557,6 +662,20 @@ const CaseworkerJourneys = () => {
                     </Badge>
                   </div>
                 )}
+                {(() => {
+                  const selectedCw = caseworkerList.find((cw: any) => cw.caseworker === appliedFilters.caseworker) as any;
+                  const district = selectedCw?.district as string | undefined;
+                  if (!district) return null;
+                  return (
+                    <div className="flex items-center gap-1.5">
+                      <MapPin className="h-3 w-3 text-emerald-500" />
+                      <span className="text-slate-500">District:</span>
+                      <Badge variant="outline" className="text-xs font-normal border-emerald-200 bg-emerald-50/60 text-emerald-700">
+                        {normalizePlaceName(district)}
+                      </Badge>
+                    </div>
+                  );
+                })()}
                 <div className="flex items-center gap-1.5">
                   <MapPin className="h-3 w-3 text-slate-400" />
                   <span className="text-slate-500">Points:</span>
@@ -574,20 +693,20 @@ const CaseworkerJourneys = () => {
               </div>
             )}
           </CardHeader>
-          <CardContent>
+          <CardContent className={cn(isMapFullscreen && "p-2 sm:p-3")}>
             {isLoading ? (
-              <div className="flex h-[500px] items-center justify-center rounded-lg bg-slate-50">
+              <div className={cn("flex items-center justify-center rounded-lg bg-slate-50", isMapFullscreen ? "h-[calc(100vh-130px)]" : "h-[500px]")}>
                 <div className="text-center">
                   <div className="mx-auto mb-3 h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
                   <p className="text-sm text-slate-500">Loading GPS data...</p>
                 </div>
               </div>
             ) : isError ? (
-              <div className="flex h-[500px] items-center justify-center rounded-lg bg-red-50">
+              <div className={cn("flex items-center justify-center rounded-lg bg-red-50", isMapFullscreen ? "h-[calc(100vh-130px)]" : "h-[500px]")}>
                 <p className="text-sm font-medium text-red-600">Failed to load journey data.</p>
               </div>
             ) : !hasServerFilter ? (
-              <div className="flex h-[500px] items-center justify-center rounded-lg bg-slate-50">
+              <div className={cn("flex items-center justify-center rounded-lg bg-slate-50", isMapFullscreen ? "h-[calc(100vh-130px)]" : "h-[500px]")}>
                 <div className="text-center max-w-md">
                   <MapPin className="mx-auto mb-3 h-10 w-10 text-slate-300" />
                   <p className="text-sm font-medium text-slate-600">Select a caseworker or date range</p>
@@ -595,7 +714,7 @@ const CaseworkerJourneys = () => {
                 </div>
               </div>
             ) : validPoints.length === 0 ? (
-              <div className="flex h-[500px] items-center justify-center rounded-lg bg-slate-50">
+              <div className={cn("flex items-center justify-center rounded-lg bg-slate-50", isMapFullscreen ? "h-[calc(100vh-130px)]" : "h-[500px]")}>
                 <div className="text-center max-w-md">
                   <MapPin className="mx-auto mb-3 h-10 w-10 text-slate-300" />
                   <p className="text-sm font-medium text-slate-600">No GPS data found for this caseworker</p>
@@ -603,7 +722,7 @@ const CaseworkerJourneys = () => {
                 </div>
               </div>
             ) : (
-              <>
+              <div>
                 {/* Playback controls - above map */}
                 {viewMode === "playback" && sortedPoints.length > 0 && (
                   <div className="mb-3 p-4 bg-slate-50 rounded-xl">
@@ -631,15 +750,15 @@ const CaseworkerJourneys = () => {
                     {playbackPoint && (
                       <div className="mt-2 flex flex-wrap gap-3 text-xs text-slate-500">
                         <span>{new Date(playbackPoint.visit_date).toLocaleString("en-GB", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
-                        {(playbackPoint as any).facility && <span className="text-blue-600 font-medium">{(playbackPoint as any).facility}</span>}
+                        {(playbackPoint as any).facility && <span className="text-blue-600 font-medium">{normalizePlaceName((playbackPoint as any).facility)}</span>}
                         {(playbackPoint as any).household_id && <span className="text-emerald-600 font-medium">ID: {(playbackPoint as any).household_id}</span>}
-                        <span>{playbackPoint.form_type}</span>
+                        <span>{categorizeVisit(playbackPoint.form_type)}</span>
                       </div>
                     )}
                   </div>
                 )}
 
-                <div className="h-[500px] overflow-hidden rounded-lg">
+                <div className={cn("overflow-hidden rounded-lg", isMapFullscreen ? "h-[calc(100vh-130px)]" : "h-[500px]")}>
                   <MapContainer center={mapCenter} zoom={mapZoom} className="h-full w-full" scrollWheelZoom={true}>
                     <TileLayer
                       attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
@@ -649,20 +768,33 @@ const CaseworkerJourneys = () => {
                     {/* Journey view */}
                     {viewMode === "journey" && (
                       <>
-                        {validPoints.map((point: any, idx: number) => (
-                          <CircleMarker key={`j-${idx}`} center={[Number(point.lat), Number(point.lng)]} radius={5}
-                            pathOptions={{ color: "#3b82f6", fillColor: "#3b82f6", fillOpacity: 0.8, weight: 1 }}>
-                            <Popup>
-                              <div className="text-sm space-y-0.5">
-                                <p className="font-semibold">{point.caseworker}</p>
-                                {point.facility && <p className="text-blue-600 font-medium">{point.facility}</p>}
-                                {point.household_id && <p className="text-emerald-600 text-xs font-medium">ID: {point.household_id}</p>}
-                                <p className="text-slate-500">{new Date(point.visit_date).toLocaleString("en-GB", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" })}</p>
-                                <p className="text-slate-400 text-xs">{point.form_type}</p>
-                              </div>
-                            </Popup>
-                          </CircleMarker>
-                        ))}
+                        {validPoints.map((point: any, idx: number) => {
+                          const visits = Number(point.visit_count || 1);
+                          const radius = visits > 1 ? Math.min(5 + Math.sqrt(visits) * 2, 12) : 5;
+                          const types: string[] = Array.isArray(point.visit_form_types) && point.visit_form_types.length > 0
+                            ? point.visit_form_types
+                            : (point.form_type ? [point.form_type] : []);
+                          return (
+                            <CircleMarker key={`j-${idx}`} center={[Number(point.lat), Number(point.lng)]} radius={radius}
+                              pathOptions={{ color: "#3b82f6", fillColor: "#3b82f6", fillOpacity: 0.8, weight: 1 }}>
+                              <Popup>
+                                <div className="text-sm space-y-0.5">
+                                  {point.facility && <p className="text-blue-600 font-semibold">{normalizePlaceName(point.facility)}</p>}
+                                  {point.household_id && <p className="text-emerald-600 text-xs font-medium">ID: {point.household_id}</p>}
+                                  <p className="text-slate-500">{new Date(point.visit_date).toLocaleString("en-GB", { day: "2-digit", month: "short", year: "numeric", hour: "2-digit", minute: "2-digit" })}</p>
+                                  {visits > 1 ? (
+                                    <p className="text-slate-400 text-xs">
+                                      <span className="inline-flex items-center px-1.5 py-0.5 mr-1 rounded bg-emerald-100 text-emerald-700 font-bold">{visits} visits</span>
+                                      {visitLabel(types)}
+                                    </p>
+                                  ) : (
+                                    <p className="text-slate-400 text-xs">{categorizeVisit(point.form_type)}</p>
+                                  )}
+                                </div>
+                              </Popup>
+                            </CircleMarker>
+                          );
+                        })}
                         {polylinePositions.length > 1 && (
                           <Polyline positions={polylinePositions} pathOptions={{ color: "#3b82f6", weight: 3, opacity: 0.7 }} />
                         )}
@@ -687,10 +819,11 @@ const CaseworkerJourneys = () => {
                     )}
                   </MapContainer>
                 </div>
-              </>
+              </div>
             )}
           </CardContent>
         </GlowCard>
+        </div>
       </div>
     </DashboardLayout>
   );


### PR DESCRIPTION
GPS Journey page
- Added a Fullscreen button (press Esc to exit) so the map can take over the whole screen for easier inspection.
- When a caseworker visits the same household or child multiple times on the same day, those points now collapse into a single pin (with a "Nx visits" chip in the popup) instead of stacking on top of each other.
- Map pins no longer expose caseworker usernames — the caseworker is already shown in the search/filter bar at the top.
- Added a District badge next to the caseworker info so HQ can tell at a glance where a ward is located.
- Map pin popups now say "Household Visit" or "Child Visit" instead of internal form codes like "ec_household_service_report".
- Ward names like "chibale" or "MULUNGUSHI" now display as proper Title Case ("Chibale", "Mulungushi"); case-variant duplicates in the dropdown are collapsed.
- Hid test / placeholder accounts (devtest, john doe, pcz pcz, ecap ecap, project pcz, test test, TestLimu, Testing WardSync, etc.) plus any caseworker with no assigned ward so the dropdown only shows real, working caseworkers.

Notifications
- The bell now refreshes every 30 seconds while the tab is in front, and pauses in background tabs.
- "Clear all" now empties the whole inbox in one server call (previously only the most-recent 20).
- Failed dismiss / clear actions now show a toast instead of silently failing.
- Replaced the broken "/notification.wav" reference with an in-browser tone; added a sound on/off toggle in the bell dropdown.
- When the tab is in the background and a new notification arrives, the browser's native notification banner fires (if the user has granted permission).
- Flag-related broadcast notifications now go only to admins / supervisors / QA roles instead of every active user.