### PR TITLE
Point deploy APP_DIR at pmp-applications-{staging,production}

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: [self-hosted, production]
     environment: production
     env:
-      APP_DIR: /home/bluecode2022/mvaccbackup/ecapbackup/production/ecap-plus-pmp
+      APP_DIR: /home/bluecode2022/mvaccbackup/ecapbackup/pmp-applications-production/ecap-plus-pmp
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, staging]
     environment: staging
     env:
-      APP_DIR: /home/bluecode2022/mvaccbackup/ecapbackup/staging/ecap-plus-pmp
+      APP_DIR: /home/bluecode2022/mvaccbackup/ecapbackup/pmp-applications-staging/ecap-plus-pmp
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Part of consolidating the scattered per-app deploy folders on the server into `pmp-applications-staging/` and `pmp-applications-production/`. Server-side folder moves are being done manually alongside this.