### PR TITLE
Merge development into main: pmp-applications folder relocation

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: [self-hosted, production]
     environment: production
     env:
-      APP_DIR: /home/bluecode2022/mvaccbackup/ecapbackup/production/ecap-plus-pmp
+      APP_DIR: /home/bluecode2022/mvaccbackup/ecapbackup/pmp-applications-production/ecap-plus-pmp
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: [self-hosted, staging]
     environment: staging
     env:
-      APP_DIR: /home/bluecode2022/mvaccbackup/ecapbackup/staging/ecap-plus-pmp
+      APP_DIR: /home/bluecode2022/mvaccbackup/ecapbackup/pmp-applications-staging/ecap-plus-pmp
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Propagates the APP_DIR path fix (PR #196) to main so production's Deploy Production workflow also targets the new pmp-applications-production/ path.